### PR TITLE
Remove explicit dependency with React.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,7 @@
     "mocha": "^2.3.3",
     "node-sass": "^3.3.3",
     "phantomjs": "^1.9.18",
-    "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.0",
-    "redbox-react": "^1.0.1",
     "resolve-url-loader": "^1.3.0",
     "rimraf": "^2.4.3",
     "sass-loader": "^3.0.0",
@@ -70,11 +68,5 @@
     "webpack": "^1.9.6",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.0.0"
-  },
-  "peerDependencies": {
-    "react": "^0.14.2"
-  },
-  "devDependencies": {
-    "react": "^0.14.2"
   }
 }

--- a/src/config/build-webpack-config.js
+++ b/src/config/build-webpack-config.js
@@ -50,9 +50,6 @@ export default function buildWebpackConfig ({ projectPath, saguiPath, pages = de
                 transform: 'react-transform-hmr',
                 imports: ['react'],
                 locals: ['module']
-              }, {
-                transform: 'react-transform-catch-errors',
-                imports: ['react', 'redbox-react']
               }]
             }
           }


### PR DESCRIPTION
Although we support React’s HMR and Linting, it is no longer a dependency, and you may use Sagui for some other type of project.