### PR TITLE
Use webpack-merge smart feature to allow modifying an existing loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ module.exports = {
 }
 ```
 
+For more information on how the merging of Webpack configurations work check [webpack-merge](https://github.com/survivejs/webpack-merge).
+
 ### Disable plugins
 
 If you need to disable any default behavior, it is possible via:

--- a/src/configure/index.spec.js
+++ b/src/configure/index.spec.js
@@ -55,6 +55,29 @@ describe('configure', function () {
       config = configure({ projectPath, saguiPath, webpackConfig }).webpackConfig
       expect(config.devtool).equal('cheap-source-map')
     })
+
+    it('should allow changing a loader based on the test (webpack-merge feature)', function () {
+      // disable the default exclude behavior of Babel
+      const webpackConfig = {
+        module: {
+          loaders: [
+            {
+              test: /\.jsx?$/,
+              loader: 'babel'
+            }
+          ]
+        }
+      }
+
+      config = configure({ projectPath, saguiPath, webpackConfig }).webpackConfig
+      const loaders = config.module.loaders.filter((loader) => loader.loader === 'babel')
+
+      // should change the existing loader, not add another
+      expect(loaders.length).equal(1)
+
+      // should remove the exclude attribute as requested
+      expect(loaders[0].exclude).undefined
+    })
   })
 
   describe('karmaConfig extension', function () {

--- a/src/configure/webpack/index.js
+++ b/src/configure/webpack/index.js
@@ -28,10 +28,10 @@ export default function configureWebpack (config) {
   const defaultWebpackConfig = plugins
     .filter(plugin => disabledPlugins.indexOf(plugin.name) === -1)
     .reduce((webpackConfig, plugin) => {
-      return merge(webpackConfig, plugin.configure(extraConfig))
+      return merge.smart(webpackConfig, plugin.configure(extraConfig))
     }, {})
 
-  const webpackConfig = merge(defaultWebpackConfig, userWebpackConfig)
+  const webpackConfig = merge.smart(defaultWebpackConfig, userWebpackConfig)
 
   return { ...config, webpackConfig }
 }


### PR DESCRIPTION
This PR leverages webpack-merge smart feature to allow changing a loader definition based on its test.